### PR TITLE
refactor: Improve robustness of SidewalkCreator class

### DIFF
--- a/sidewalk_creator.py
+++ b/sidewalk_creator.py
@@ -38,8 +38,13 @@ class SidewalkCreator:
                 if not i == j:
                     if line.intersects(line2):
                         intersec = line.intersection(line2)
-                        intersections_dict['names'].append(f'{i}_{j}')
-                        intersections_dict['geometry'].append(intersec)
+                        if intersec.geom_type == 'Point':
+                            intersections_dict['names'].append(f'{i}_{j}')
+                            intersections_dict['geometry'].append(intersec)
+                        elif intersec.geom_type == 'MultiPoint':
+                            for p in intersec.geoms:
+                                intersections_dict['names'].append(f'{i}_{j}')
+                                intersections_dict['geometry'].append(p)
 
         if return_gdf:
             return gpd.GeoDataFrame(intersections_dict, crs=self.proj_epsg)


### PR DESCRIPTION
This commit improves the robustness of the `SidewalkCreator` class by handling different geometry types that can be returned by the `intersection` and `polygonize_full` methods.

The `_find_intersections` method has been updated to only include `Point` and `MultiPoint` geometries in the intersections dictionary. This prevents `TypeError` exceptions when creating the `MultiPoint` object.

The `_create_sidewalks` method has been updated to handle `GeometryCollection` objects returned by the `polygonize_full` function.

The `_multigeom_to_gdf` method has been refactored to handle `GeometryCollection` objects and the unused `outfilepath` argument has been removed.

A deprecation warning in the `_point_between_two` method has also been fixed.