### PR TITLE
Add osmnx and networkx dependencies for differences experiment

### DIFF
--- a/differences_experiment/requirements.txt
+++ b/differences_experiment/requirements.txt
@@ -3,4 +3,6 @@ matplotlib
 wordcloud
 tqdm
 pytest
+networkx>=3.5
+osmnx>=2.0.6
 


### PR DESCRIPTION
## Summary
- include `networkx` and `osmnx` in the differences experiment requirements
- pin versions compatible with the workflow's Python runtime

## Testing
- `pip install -r differences_experiment/requirements.txt`
- `pytest differences_experiment`


------
https://chatgpt.com/codex/tasks/task_b_689a382f14e4832f81dfdd9329d434ec