### PR TITLE
Compute sidewalk metrics for largest cities via osmnx

### DIFF
--- a/differences_experiment/test_largest_cities_differences.py
+++ b/differences_experiment/test_largest_cities_differences.py
@@ -1,30 +1,67 @@
 from pathlib import Path
+from unittest.mock import patch
 
 from differences_experiment.largest_cities_differences import (
-    DATA_SAMPLE,
     build_dataframe,
     save_boxplot,
     save_wordcloud,
 )
 
+SAMPLE_METRICS = {
+    "Tokyo": {
+        "car_len": 1.0,
+        "footway_len": 2.0,
+        "sidewalk_len": 0.5,
+        "with_sidewalk": 0.25,
+    },
+    "Delhi": {
+        "car_len": 2.0,
+        "footway_len": 3.0,
+        "sidewalk_len": 0.7,
+        "with_sidewalk": 0.35,
+    },
+    "Shanghai": {
+        "car_len": 3.0,
+        "footway_len": 4.0,
+        "sidewalk_len": 0.9,
+        "with_sidewalk": 0.45,
+    },
+}
+
+
+def fake_metrics(city: str) -> dict[str, float]:
+    return SAMPLE_METRICS[city]
+
 
 def test_build_dataframe_columns():
     names = ["Tokyo", "Delhi", "Shanghai"]
-    df = build_dataframe(names, DATA_SAMPLE)
+    with patch(
+        "differences_experiment.largest_cities_differences.compute_city_metrics",
+        side_effect=fake_metrics,
+    ):
+        df = build_dataframe(names)
     expected_cols = ["city", "car_len", "footway_len", "sidewalk_len", "with_sidewalk"]
     assert list(df.columns) == expected_cols
     assert len(df) == 3
 
 
-def test_save_boxplot(tmp_path):
-    df = build_dataframe(["Tokyo", "Delhi"], DATA_SAMPLE)
+def test_save_boxplot(tmp_path: Path):
+    with patch(
+        "differences_experiment.largest_cities_differences.compute_city_metrics",
+        side_effect=fake_metrics,
+    ):
+        df = build_dataframe(["Tokyo", "Delhi"])
     out = tmp_path / "boxplot.png"
     save_boxplot(df, out)
     assert out.exists()
 
 
-def test_save_wordcloud(tmp_path):
-    df = build_dataframe(["Tokyo", "Delhi"], DATA_SAMPLE)
+def test_save_wordcloud(tmp_path: Path):
+    with patch(
+        "differences_experiment.largest_cities_differences.compute_city_metrics",
+        side_effect=fake_metrics,
+    ):
+        df = build_dataframe(["Tokyo", "Delhi"])
     out = tmp_path / "wordcloud.png"
     save_wordcloud(df, out)
     assert out.exists()


### PR DESCRIPTION
## Summary
- Load the top 1000 city names and use osmnx to retrieve street and sidewalk networks
- Sum drive, footway, sidewalk, and sidewalk-tagged road lengths for each city
- Generate boxplots and word clouds from the computed metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a382d2dfc832f9461e00672857f81