### PR TITLE
Handle zero sidewalk data when generating wordcloud

### DIFF
--- a/cities_experiment/functions.py
+++ b/cities_experiment/functions.py
@@ -35,8 +35,18 @@ def generate_boxplot(data, output_folder):
 
 def generate_wordcloud(data, output_folder):
     with_sidewalk_data = {city: data[city].get('with_sidewalk', 0) for city in data}
+    total_sidewalks = sum(with_sidewalk_data.values())
+    if total_sidewalks == 0:
+        plt.figure(figsize=(15, 10))
+        plt.text(0.5, 0.5, 'No sidewalk data available', ha='center', va='center', fontsize=20)
+        plt.axis('off')
+        plt.savefig(os.path.join(output_folder, 'sidewalk_wordcloud.png'))
+        plt.close()
+        return
     wordcloud = WordCloud(width=800, height=400, background_color='white').generate_from_frequencies(with_sidewalk_data)
     plt.figure(figsize=(15, 10))
     plt.imshow(wordcloud, interpolation='bilinear')
     plt.axis('off')
     plt.savefig(os.path.join(output_folder, 'sidewalk_wordcloud.png'))
+    plt.close()
+

--- a/test_generate_wordcloud.py
+++ b/test_generate_wordcloud.py
@@ -1,0 +1,12 @@
+from cities_experiment.functions import generate_wordcloud
+
+def test_generate_wordcloud_zero_data(tmp_path):
+    data = {
+        "CityA": {"with_sidewalk": 0},
+        "CityB": {"with_sidewalk": 0},
+    }
+    generate_wordcloud(data, tmp_path)
+    output_file = tmp_path / 'sidewalk_wordcloud.png'
+    assert output_file.exists()
+    assert output_file.stat().st_size > 0
+


### PR DESCRIPTION
## Summary
- Safely handle cases with no sidewalk data when building city word clouds
- Generate placeholder image when sidewalk counts are zero
- Add unit test covering empty sidewalk data scenario

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cf1796ae8832f95d9f2238a1b0e24