### PR TITLE
Use local PBF extracts for city experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ tests.py
 # OSMNX cache
 cache
 *.ods#
+
+# Local OSM PBF extracts
+*.osm.pbf

--- a/README.md
+++ b/README.md
@@ -19,3 +19,20 @@ You might need to install the requirements for the analysis (from the repository
     <your_python_executable_path> -m pip install -r requirements.txt
 
 *: Some charts were generated in QGIS, and the projects of the publication were kept here, but there's no actually automated way of reproducing. Some charts were generated using Colab Notebooks, available in the folder called "chart_generation_notebooks", some may need some sort of fine-tuning to render properly meaningful charts.
+
+## Cities experiment
+
+The standard utility at `cities_experiment/main.py` fetches data directly
+from the OpenStreetMap API using OSMnx. For offline analysis, you have two
+options:
+
+* `cities_experiment/main_pbf.py` expects pre-cut `.osm.pbf` extracts. Download
+  the desired files (for example, from [Geofabrik](https://download.geofabrik.de/))
+  and place them in `cities_experiment/pbfs` using the pattern
+  `<city_name>.osm.pbf` (spaces replaced by underscores).
+* `cities_experiment/main_planet.py` works with a single
+  `planet-latest.osm.pbf` placed in the `cities_experiment` folder. The script
+  geocodes each city to a bounding box and filters the planet file locally using
+  [Pyrosm](https://github.com/HTenkanen/pyrosm).
+
+Both scripts rely on Pyrosm, which is listed in the project requirements.

--- a/cities_experiment/main_pbf.py
+++ b/cities_experiment/main_pbf.py
@@ -1,0 +1,93 @@
+import os
+import pandas as pd
+from pyrosm import OSM
+
+# from cities_experiment.functions import read_json, dump_json, calc_len_sum, generate_boxplot, generate_wordcloud
+
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from functions import (
+    read_json,
+    dump_json,
+    calc_len_sum,
+    generate_boxplot,
+    generate_wordcloud,
+)
+
+
+def main():
+    csvpath = "cities_experiment/biggest_cities.csv"
+    outpath = "cities_experiment/biggest_cities_23set2022.json"
+    outfiles_folderpath = "cities_experiment/geojsons"
+    pbf_folderpath = "cities_experiment/pbfs"
+    output_folder = "cities_experiment"
+
+    if not os.path.exists(outfiles_folderpath):
+        os.makedirs(outfiles_folderpath)
+    if not os.path.exists(pbf_folderpath):
+        os.makedirs(pbf_folderpath)
+
+    cities_df = pd.read_csv(csvpath)
+
+    if not os.path.exists(outpath):
+        data = {}
+    else:
+        data = read_json(outpath)
+
+    filters = {
+        "car_len": {
+            "highway": [
+                "motorway",
+                "trunk",
+                "primary",
+                "tertiary",
+                "unclassified",
+                "residential",
+            ]
+        },
+        "footway_len": {"highway": ["footway", "path"]},
+        "sidewalk_len": {"footway": ["sidewalk", "crossing"]},
+        "with_sidewalk": {"sidewalk": True},
+    }
+
+    for i, cityname in enumerate(cities_df["Name"]):
+        try:
+            if i > 20:  # Limiting to 20 cities for testing purposes
+                break
+            if not cityname in data:
+                data[cityname] = {}
+            city_slug = cityname.replace(" ", "_").lower()
+            pbf_path = os.path.join(pbf_folderpath, f"{city_slug}.osm.pbf")
+            if not os.path.exists(pbf_path):
+                print(f"PBF file for {cityname} not found at {pbf_path}. Skipping city.")
+                continue
+            osm = OSM(pbf_path)
+            for category in filters:
+                print(i, cityname, category)
+                if not category in data[cityname]:
+                    print(i, cityname, category)
+                    print()
+                    outpath_file = os.path.join(
+                        outfiles_folderpath, f"{cityname}_{category}.geojson"
+                    )
+                    current_gdf = osm.get_data_by_custom_criteria(
+                        custom_filter=filters[category], filter_type="keep", data_type="lines"
+                    )
+                    data[cityname][category] = calc_len_sum(current_gdf)
+                    dump_json(data, outpath)
+                    # current_gdf.to_file(outpath_file, driver='GeoJSON') # Disabling to avoid large files
+        except Exception as e:
+            print(f"Error processing {cityname}: {e}")
+            if cityname in data:
+                del data[cityname]
+
+    if os.path.exists(outpath):
+        data = read_json(outpath)
+
+    generate_boxplot(data, output_folder)
+    generate_wordcloud(data, output_folder)
+
+
+if __name__ == "__main__":
+    main()

--- a/cities_experiment/main_planet.py
+++ b/cities_experiment/main_planet.py
@@ -1,0 +1,85 @@
+import os
+import pandas as pd
+import osmnx as ox
+from pyrosm import OSM
+
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from functions import read_json, dump_json, calc_len_sum, generate_boxplot, generate_wordcloud
+
+
+def main():
+    csvpath = "cities_experiment/biggest_cities.csv"
+    outpath = "cities_experiment/biggest_cities_planet.json"
+    outfiles_folderpath = "cities_experiment/geojsons"
+    planet_pbf = "cities_experiment/planet-latest.osm.pbf"
+    output_folder = "cities_experiment"
+
+    if not os.path.exists(outfiles_folderpath):
+        os.makedirs(outfiles_folderpath)
+
+    cities_df = pd.read_csv(csvpath)
+
+    if not os.path.exists(outpath):
+        data = {}
+    else:
+        data = read_json(outpath)
+
+    if not os.path.exists(planet_pbf):
+        raise FileNotFoundError(
+            f"Planet file not found at {planet_pbf}. Download from https://planet.openstreetmap.org/"
+        )
+
+    filters = {
+        "car_len": {
+            "highway": [
+                "motorway",
+                "trunk",
+                "primary",
+                "tertiary",
+                "unclassified",
+                "residential",
+            ]
+        },
+        "footway_len": {"highway": ["footway", "path"]},
+        "sidewalk_len": {"footway": ["sidewalk", "crossing"]},
+        "with_sidewalk": {"sidewalk": True},
+    }
+
+    for i, row in cities_df.iterrows():
+        cityname = row["Name"]
+        if i > 20:  # Limiting to 20 cities for testing purposes
+            break
+        if cityname not in data:
+            data[cityname] = {}
+        try:
+            geocode_str = f"{cityname}, {row['Country']}"
+            city_geom = ox.geocode_to_gdf(geocode_str).unary_union
+            bbox = city_geom.bounds
+            osm = OSM(planet_pbf, bounding_box=bbox)
+            for category in filters:
+                if category in data[cityname]:
+                    continue
+                print(i, cityname, category)
+                current_gdf = osm.get_data_by_custom_criteria(
+                    custom_filter=filters[category],
+                    filter_type="keep",
+                    data_type="lines",
+                )
+                data[cityname][category] = calc_len_sum(current_gdf)
+                dump_json(data, outpath)
+        except Exception as e:
+            print(f"Error processing {cityname}: {e}")
+            if cityname in data:
+                del data[cityname]
+
+    if os.path.exists(outpath):
+        data = read_json(outpath)
+
+    generate_boxplot(data, output_folder)
+    generate_wordcloud(data, output_folder)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ Levenshtein
 shapely>2.0
 plotly
 kaleido
+pyrosm
 tqdm


### PR DESCRIPTION
## Summary
- document two offline pathways for city metrics: per-city PBF extracts and a single `planet-latest.osm.pbf`
- add `cities_experiment/main_planet.py` to slice the planet file for each city using Pyrosm

## Testing
- `pip install matplotlib wordcloud pandas`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cf3b70b64832fbe52661736ea0a7e