### PR TITLE
Fix: Increase timeout for Overpass API requests

### DIFF
--- a/cities_experiment/main.py
+++ b/cities_experiment/main.py
@@ -4,6 +4,7 @@ import pandas as pd
 from cities_experiment.functions import read_json, dump_json, calc_len_sum, generate_boxplot, generate_wordcloud
 
 def main():
+    ox.settings.timeout = 3600
     csvpath = "cities_experiment/biggest_cities.csv"
     outpath = "cities_experiment/biggest_cities_23set2022.json"
     outfiles_folderpath = "cities_experiment/geojsons"

--- a/cities_experiment/sample_check.py
+++ b/cities_experiment/sample_check.py
@@ -4,6 +4,7 @@ import pandas as pd
 from cities_experiment.functions import read_json, dump_json, calc_len_sum, generate_boxplot, generate_wordcloud
 
 def main():
+    ox.settings.timeout = 3600
     csvpath = "cities_experiment/biggest_cities.csv"
     output_folder = "cities_experiment/sample_check"
     outpath = os.path.join(output_folder, "biggest_cities_sample.json")


### PR DESCRIPTION
This commit increases the timeout for Overpass API requests to 60 minutes. This should prevent the `Read timed out` error when downloading data for large cities.