### PR TITLE
Add Plotly notebook analyzing city network lengths

### DIFF
--- a/cities_experiment/city_network_lengths_analysis.ipynb
+++ b/cities_experiment/city_network_lengths_analysis.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6dea84da",
+   "metadata": {},
+   "source": [
+    "# City Network Lengths Analysis\n",
+    "This notebook explores the `city_network_lengths.csv` dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97821f15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import plotly.express as px\n",
+    "\n",
+    "# Load dataset\n",
+    "df = pd.read_csv('city_network_lengths.csv')\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "908149b4",
+   "metadata": {},
+   "source": [
+    "## Boxplot of Network Lengths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbc9fca0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.box(df, y=['car_len_m', 'footway_len_m', 'sidewalk_len_m', 'with_sidewalk_len_m'], title='Distribution of Network Lengths')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e94575d6",
+   "metadata": {},
+   "source": [
+    "## Histogram of Sidewalk Lengths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9de7a7d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.histogram(df, x='sidewalk_len_m', nbins=30, title='Histogram of Sidewalk Lengths')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d91e3ba3",
+   "metadata": {},
+   "source": [
+    "## Scatter Plot: Population vs Car Network Length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac28cbf3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.scatter(df, x='population', y='car_len_m', hover_name='city', title='Population vs Car Network Length')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48f3bf48",
+   "metadata": {},
+   "source": [
+    "## Bar Chart: Top 10 Cities by Sidewalk Length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b37c16a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_sorted = df.nlargest(10, 'sidewalk_len_m')\n",
+    "px.bar(df_sorted, x='city', y='sidewalk_len_m', title='Top 10 Cities by Sidewalk Length')"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create `city_network_lengths_analysis.ipynb` with Plotly visualizations for car, footway, and sidewalk networks
- include boxplot, histogram, scatter, and bar charts for exploring `city_network_lengths.csv`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fb8b79378832f834de8ba49c67f4a